### PR TITLE
test: add code coverage report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 /config/test.key
 
 /config/application.yml
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'webdrivers'
+  gem 'simplecov', require: false
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     errbase (0.2.0)
@@ -309,6 +310,10 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 2.0.6, < 2.1)
@@ -399,6 +404,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (~> 5.0)
   selenium-webdriver
+  simplecov
   slim-rails
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/bin/rails
+++ b/bin/rails
@@ -1,9 +1,16 @@
 #!/usr/bin/env ruby
+if ENV['RAILS_ENV'] == 'test'
+  require 'simplecov'
+  SimpleCov.start 'rails'
+  Rails.application.eager_load!
+end
+
 begin
   load File.expand_path('../spring', __FILE__)
 rescue LoadError => e
   raise unless e.message.include?('spring')
 end
+
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_24_213407) do
+ActiveRecord::Schema.define(version: 2020_04_11_205152) do
 
   create_table "addresses", force: :cascade do |t|
     t.integer "user_id"
@@ -28,6 +28,17 @@ ActiveRecord::Schema.define(version: 2019_09_24_213407) do
     t.index ["country_id"], name: "index_addresses_on_country_id"
     t.index ["state_id"], name: "index_addresses_on_state_id"
     t.index ["user_id"], name: "index_addresses_on_user_id"
+  end
+
+  create_table "ambassadors", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.integer "course_id", null: false
+    t.integer "admission_year", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "is_active", default: true
+    t.index ["course_id"], name: "index_ambassadors_on_course_id"
+    t.index ["user_id"], name: "index_ambassadors_on_user_id"
   end
 
   create_table "contact_types", force: :cascade do |t|
@@ -48,6 +59,13 @@ ActiveRecord::Schema.define(version: 2019_09_24_213407) do
   create_table "countries", force: :cascade do |t|
     t.string "name", null: false
     t.integer "order_index"
+    t.string "code"
+  end
+
+  create_table "courses", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "education_informations", force: :cascade do |t|
@@ -64,6 +82,13 @@ ActiveRecord::Schema.define(version: 2019_09_24_213407) do
 
   create_table "education_levels", force: :cascade do |t|
     t.string "name", null: false
+  end
+
+  create_table "error_logs", force: :cascade do |t|
+    t.string "category"
+    t.text "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "intended_relationships", force: :cascade do |t|
@@ -161,6 +186,9 @@ ActiveRecord::Schema.define(version: 2019_09_24_213407) do
     t.datetime "updated_at", null: false
     t.boolean "admin"
     t.boolean "agreement"
+    t.integer "ambassador_id"
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
+require 'simplecov'
+SimpleCov.start 'rails'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 require 'rails/test_help'
+Rails.application.eager_load!
 
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.


### PR DESCRIPTION
Este PR adiciona simplecov como ferramenta de geração de code coverage report.

Basicamente depois de rodar os testes, vai ser gerado uma página em `coverage/index.html` que se você abrir no navegador vai mostrar o report de forma organizada.

Parte da issue #71 